### PR TITLE
Tender.subcontracting => Tender.subcontractingTerms

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ In the European Union, this extension's fields correspond to [eForms BG-709 (Sec
 
 ```json
 {
+  "tender": {
+    "subcontractingTerms": {
+      "description": "The successful tenderer is obliged to specify which part or parts of the contract it intends to subcontract beyond the required percentage and to indicate the subcontractors already identified."
+    }
+  }
+}
+```
+
+```json
+{
   "awards": [
     {
       "id": "1",
@@ -68,6 +78,10 @@ In the European Union, this extension's fields correspond to [eForms BG-709 (Sec
 Report issues for this extension in the [ocds-extensions repository](https://github.com/open-contracting/ocds-extensions/issues), putting the extension's name in the issue's title.
 
 ## Changelog
+
+### 2020-10-07
+
+* Rename the `subcontracting` in the `Tender` object as `subcontractingTerms`.
 
 ### 2020-04-24
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
 
 ### 2020-10-07
 
-* Rename the `subcontracting` in the `Tender` object as `subcontractingTerms`.
+* Rename the `subcontracting` field in the `Tender` object to `subcontractingTerms`.
 
 ### 2020-04-24
 

--- a/release-schema.json
+++ b/release-schema.json
@@ -1,5 +1,14 @@
 {
   "definitions": {
+    "Tender": {
+      "properties": {
+        "subcontractingTerms": {
+          "title": "Subcontracting terms",
+          "description": "The obligations of the suppliers who subcontract.",
+          "$ref": "#/definitions/SubcontractingTerms"
+        }
+      }
+    },
     "Award": {
       "properties": {
         "hasSubcontracting": {
@@ -16,6 +25,23 @@
           "$ref": "#/definitions/Subcontracting"
         }
       }
+    },
+    "SubcontractingTerms": {
+      "title": "Subcontracting terms",
+      "description": "The obligations of the suppliers who subcontract.",
+      "type": "object",
+      "properties": {
+        "description": {
+          "title": "Description",
+          "description": "The description of the obligations that fall to the suppliers who subcontract.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
+        }
+      },
+      "minProperties": 1
     },
     "Subcontracting": {
       "title": "Subcontracting",

--- a/release-schema.json
+++ b/release-schema.json
@@ -4,7 +4,7 @@
       "properties": {
         "subcontractingTerms": {
           "title": "Subcontracting terms",
-          "description": "The obligations of the suppliers who subcontract.",
+          "description": "Information about the terms governing subcontracting.",
           "$ref": "#/definitions/SubcontractingTerms"
         }
       }

--- a/release-schema.json
+++ b/release-schema.json
@@ -33,7 +33,7 @@
       "properties": {
         "description": {
           "title": "Description",
-          "description": "The description of the obligations that fall to the suppliers who subcontract.",
+          "description": "A description of the terms governing subcontracting.",
           "type": [
             "string",
             "null"


### PR DESCRIPTION
I have renamed `Tender.subcontracting` to `Tender.subcontractingTerms`, and only added the `description` property, with semantics adapted to the context of a tender.

Closes https://github.com/open-contracting/ocds-extensions/issues/149