### PR TITLE
Update for eForms

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Information about the terms governing subcontracting is disclosed per lot at the
                 "id": "ORG-0012",
                 "name": "Company ABC"
               },
-              "tenderers": [
+              "mainContractors": [
                 {
                   "id": "ORG-0005",
                   "name": "Tendering Company Ltd"

--- a/README.md
+++ b/README.md
@@ -10,16 +10,7 @@ If the percentage of the contract value that is subcontracted is an exact number
 
 ## Legal context
 
-In the European Union, this extension's fields correspond to [article 21 of directive 2009/81/EC](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32009L0081&from=EN#d1e2623-76-1) and the following [eForms business terms](https://docs.ted.europa.eu/eforms/latest/reference/business-terms/):
-
-* BT-773 (Subcontracting)
-* BT-553 (Subcontracting Value)
-* BT-554 (Subcontracting Description)
-* BT-555 (Subcontracting Percentage)
-* OPT-301 (Main Contractor ID Reference, Subcontractor ID Reference)
-* BT-64 (Subcontracting Obligation Minimum)
-* BT-65 (Subcontracting Obligation)
-* BT-729 (Subcontracting Obligation Maximum)
+In the European Union, this extension's fields correspond to [article 21 of directive 2009/81/EC](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32009L0081&from=EN#d1e2623-76-1) and the [eForms business terms](https://docs.ted.europa.eu/eforms/latest/reference/business-terms/) in BG-180 (Subcontracting) and BG-711 (Contract Terms).
 
 For correspondences to eForms fields, see [OCDS for eForms](https://standard.open-contracting.org/profiles/eforms/latest/en/). For correspondences to Tenders Electronic Daily (TED), see [OCDS for the European Union](http://standard.open-contracting.org/profiles/eu/master/en/).
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,33 @@
 # Subcontracting
 
-Adds an object for information about the parts of the contract that the supplier will subcontract to third parties.
+Adds objects for information about the terms governing subcontracting and the parts of the contract that tenderers and suppliers will subcontract to third parties.
 
 ## Guidance
+
+If you are using the [Lots extension](https://extensions.open-contracting.org/en/extensions/lots/master/), [follow its guidance](https://extensions.open-contracting.org/en/extensions/lots/master/#usage) on whether to use `tender.lots` fields or `tender` fields.
 
 If the percentage of the contract value that is subcontracted is an exact number and not a range, set `minimumPercentage` and `maximumPercentage` to the same number.
 
 ## Legal context
 
-In the European Union, this extension's fields correspond to [eForms BG-709 (Second Stage), BT-65, BT-64, BT-729](https://docs.ted.europa.eu/eforms/latest/reference/business-terms/) and [article 21 of directive 2009/81/EC](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32009L0081&from=EN#d1e2623-76-1). See [OCDS for the European Union](http://standard.open-contracting.org/profiles/eu/master/en/) for the correspondences to Tenders Electronic Daily (TED).
+In the European Union, this extension's fields correspond to [article 21 of directive 2009/81/EC](https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32009L0081&from=EN#d1e2623-76-1) and the following [eForms business terms](https://docs.ted.europa.eu/eforms/latest/reference/business-terms/):
+
+* BT-773 (Subcontracting)
+* BT-553 (Subcontracting Value)
+* BT-554 (Subcontracting Description)
+* BT-555 (Subcontracting Percentage)
+* OPT-301 (Main Contractor ID Reference, Subcontractor ID Reference)
+* BT-64 (Subcontracting Obligation Minimum)
+* BT-65 (Subcontracting Obligation)
+* BT-729 (Subcontracting Obligation Maximum)
+
+For correspondences to eForms fields, see [OCDS for eForms](https://standard.open-contracting.org/profiles/eforms/latest/en/). For correspondences to Tenders Electronic Daily (TED), see [OCDS for the European Union](http://standard.open-contracting.org/profiles/eu/master/en/).
 
 ## Examples
+
+### Tender and awards
+
+In the following example, information about the terms governing subcontracting is disclosed at the tender and award stages, and information about the parts of the contract that the supplier will subcontract is disclosed at the award stage.
 
 ```json
 {
@@ -18,12 +35,7 @@ In the European Union, this extension's fields correspond to [eForms BG-709 (Sec
     "subcontractingTerms": {
       "description": "The successful tenderer is obliged to specify which part or parts of the contract it intends to subcontract beyond the required percentage and to indicate the subcontractors already identified."
     }
-  }
-}
-```
-
-```json
-{
+  },
   "awards": [
     {
       "id": "1",
@@ -34,36 +46,8 @@ In the European Union, this extension's fields correspond to [eForms BG-709 (Sec
           "amount": 28000,
           "currency": "EUR"
         },
-        "description": "The painting and electricity tasks are subcontracted."
-      }
-    }
-  ]
-}
-```
-
-```json
-{
-  "awards": [
-    {
-      "id": "1",
-      "hasSubcontracting": true,
-      "subcontracting": {
         "minimumPercentage": 0.3,
         "maximumPercentage": 0.3,
-        "description": "The painting and electricity tasks are subcontracted."
-      }
-    }
-  ]
-}
-```
-
-```json
-{
-  "awards": [
-    {
-      "id": "1",
-      "hasSubcontracting": true,
-      "subcontracting": {
         "competitiveMinimumPercentage": 0.1,
         "competitiveMaximumPercentage": 0.25,
         "description": "The painting and electricity tasks are subcontracted."
@@ -73,11 +57,92 @@ In the European Union, this extension's fields correspond to [eForms BG-709 (Sec
 }
 ```
 
+### Lots and bids
+
+In the following example, information about the terms governing subcontract is disclosed per lot at the tender stage, and information about the parts of the contract that the tenderer will subcontract is disclosed at the bid stage.
+
+```json
+{
+  "parties": [
+    {
+      "id": "ORG-0005",
+      "roles": [
+        "tenderer"
+      ]
+    },
+    {
+      "id": "ORG-0012",
+      "roles": [
+        "subcontractor"
+      ]
+    }
+  ],
+  "tender": {
+    "lots": [
+      {
+        "id": "1",
+        "subcontractingTerms": {
+          "description": "The contractor must subcontract a minimum percentage of the contract using the procedure set out in Title III of Directive 2009/81/EC.",
+          "competitiveMinimumPercentage": 0.255,
+          "competitiveMaximumPercentage": 0.455
+        }
+      }
+    ]
+  },
+  "bids": {
+    "details": [
+      {
+        "id": "1",
+        "hasSubcontracting": true,
+        "subcontracting": {
+          "description": "The subcontracting will be...",
+          "value": {
+            "amount": 9999999.99,
+            "currency": "EUR"
+          },
+          "minimumPercentage": 0.3,
+          "maximumPercentage": 0.3,
+          "subcontracts": [
+            {
+              "id": "1",
+              "subcontractor": {
+                "id": "ORG-0012",
+                "name": "Company ABC"
+              },
+              "tenderers": [
+                {
+                  "id": "ORG-0005",
+                  "name": "Tendering Company Ltd"
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
 ## Issues
 
 Report issues for this extension in the [ocds-extensions repository](https://github.com/open-contracting/ocds-extensions/issues), putting the extension's name in the issue's title.
 
 ## Changelog
+
+### 2023-05-22
+
+* Add fields for eForms:
+  * `Bid.hasSubcontracting`
+  * `Bid.subcontracting`
+  * `SubcontractingTerms.competitiveMaximumPercentage`
+  * `SubcontractingTerms.competitiveMinimumPercentage`
+  * `Subcontracting.subcontracts`
+* Update descriptions for eForms:
+  * `Subcontracting`
+  * `Subcontracting.description`
+  * `Subcontracting.value`
+* Add 'subcontractor' to party role codelist.
 
 ### 2022-07-18
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For correspondences to eForms fields, see [OCDS for eForms](https://standard.ope
 
 ### Tender and awards
 
-In the following example, information about the terms governing subcontracting is disclosed at the tender and award stages, and information about the parts of the contract that the supplier will subcontract is disclosed at the award stage.
+Information about the terms governing subcontracting is disclosed at the tender and award stages, and information about the parts of the contract that the supplier will subcontract is disclosed at the award stage.
 
 ```json
 {
@@ -59,7 +59,7 @@ In the following example, information about the terms governing subcontracting i
 
 ### Lots and bids
 
-In the following example, information about the terms governing subcontracting is disclosed per lot at the tender stage, and information about the parts of the contract that the tenderer will subcontract is disclosed at the bid stage.
+Information about the terms governing subcontracting is disclosed per lot at the tender stage, and information about the parts of the contract that the tenderer will subcontract is disclosed at the bid stage.
 
 ```json
 {
@@ -138,7 +138,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
   * `SubcontractingTerms.competitiveMaximumPercentage`
   * `SubcontractingTerms.competitiveMinimumPercentage`
   * `Subcontracting.subcontracts`
-* Update descriptions for eForms:
+* Update field descriptions to allow the `Subcontracting` object to be used in the context of bids:
   * `Subcontracting`
   * `Subcontracting.description`
   * `Subcontracting.value`

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ In the following example, information about the terms governing subcontracting i
 
 ### Lots and bids
 
-In the following example, information about the terms governing subcontract is disclosed per lot at the tender stage, and information about the parts of the contract that the tenderer will subcontract is disclosed at the bid stage.
+In the following example, information about the terms governing subcontracting is disclosed per lot at the tender stage, and information about the parts of the contract that the tenderer will subcontract is disclosed at the bid stage.
 
 ```json
 {

--- a/codelists/+partyRole.csv
+++ b/codelists/+partyRole.csv
@@ -1,0 +1,2 @@
+Code,Title,Description
+subcontractor,Subcontractor,An organization that will perform part of a contract on behalf of a supplier.

--- a/extension.json
+++ b/extension.json
@@ -3,7 +3,7 @@
     "en": "Subcontracting"
   },
   "description": {
-    "en": "Adds an object for information about the parts of the contract that the supplier will subcontract to third parties."
+    "en": "Adds objects for information about the terms governing subcontracting and the parts of the contract that tenderers and suppliers will subcontract to third parties."
   },
   "documentationUrl": {
     "en": "https://extensions.open-contracting.org/en/extensions/subcontracting/"
@@ -14,8 +14,12 @@
   "schemas": [
     "release-schema.json"
   ],
+  "codelists": [
+    "+partyRole.csv"
+  ],
   "testDependencies": [
-    "https://raw.githubusercontent.com/open-contracting-extensions/ocds_lots_extension/master/extension.json"
+    "https://raw.githubusercontent.com/open-contracting-extensions/ocds_lots_extension/master/extension.json",
+    "https://raw.githubusercontent.com/open-contracting-extensions/ocds_bid_extension/master/extension.json"
   ],
   "contactPoint": {
     "name": "Open Contracting Partnership",

--- a/release-schema.json
+++ b/release-schema.json
@@ -192,7 +192,7 @@
         },
         "mainContractors": {
           "title": "Main contractors",
-          "description": "The organizations to which the subcontractor will be subcontracted, if they are a subset of the tenderers submitting the bid or the suppliers receiving an award.",
+          "description": "The organizations to which the subcontractor will be subcontracted, if they are a subset of the tenderers submitting the bid or the suppliers receiving the award.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/OrganizationReference"

--- a/release-schema.json
+++ b/release-schema.json
@@ -190,9 +190,9 @@
           "description": "The organization that performs part of the contract on behalf of the suppliers.",
           "$ref": "#/definitions/OrganizationReference"
         },
-        "tenderers": {
-          "title": "Tenderers",
-          "description": "The tenderers to which the subcontractor will be subcontracted.",
+        "mainContractors": {
+          "title": "Main contractors",
+          "description": "The organizations to which the subcontractor will be subcontracted, if they are a subset of the tenderers submitting the bid or the suppliers receiving an award.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/OrganizationReference"

--- a/release-schema.json
+++ b/release-schema.json
@@ -35,6 +35,23 @@
         }
       }
     },
+    "Bid": {
+      "properties": {
+        "hasSubcontracting": {
+          "title": "Subcontracting involved",
+          "description": "Whether a part of the contract will be subcontracted.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
+        "subcontracting": {
+          "title": "Subcontracting",
+          "description": "Information about the parts of the contract that will be subcontracted to third parties.",
+          "$ref": "#/definitions/Subcontracting"
+        }
+      }
+    },
     "SubcontractingTerms": {
       "title": "Subcontracting terms",
       "description": "The obligations of the suppliers who subcontract.",
@@ -48,18 +65,39 @@
             "null"
           ],
           "minLength": 1
+        },
+        "competitiveMaximumPercentage": {
+          "title": "Maximum percentage of contract value for competitive subcontracting",
+          "description": "The maximum percentage of the contract value that the procuring entity requires the supplier to subcontract to third parties through a competitive procedure.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "maximum": 1,
+          "minimum": 0,
+          "exclusiveMinimum": true
+        },
+        "competitiveMinimumPercentage": {
+          "title": "Minimum percentage of contract value for competitive subcontracting",
+          "description": "The minimum percentage of the contract value that the procuring entity requires the supplier to subcontract to third parties through a competitive procedure.",
+          "type": [
+            "number",
+            "null"
+          ],
+          "maximum": 1,
+          "minimum": 0
         }
       },
       "minProperties": 1
     },
     "Subcontracting": {
       "title": "Subcontracting",
-      "description": "Information about the parts of the contract that the supplier will subcontract to third parties.",
+      "description": "Information about the parts of the contract that will be subcontracted to third parties.",
       "type": "object",
       "properties": {
         "description": {
           "title": "Description",
-          "description": "The description of the part of the contract that the supplier will subcontract to third parties.",
+          "description": "The description of the part of the contract that will be subcontracted to third parties.",
           "type": [
             "string",
             "null"
@@ -110,7 +148,7 @@
         },
         "value": {
           "title": "Subcontracted value",
-          "description": "The estimated value of the part of the contract that the supplier will subcontract to third parties.",
+          "description": "The estimated value of the part of the contract that will be subcontracted to third parties.",
           "$ref": "#/definitions/Value"
         },
         "competitive": {
@@ -120,8 +158,52 @@
             "boolean",
             "null"
           ]
+        },
+        "subcontracts": {
+          "title": "Subcontracts",
+          "description": "Information about the subcontracts that will be established.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Subcontract"
+          },
+          "uniqueItems": true,
+          "minItems": 1
         }
       },
+      "minProperties": 1
+    },
+    "Subcontract": {
+      "title": "Subcontract",
+      "description": "A relationship that the tenderers will establish with a third party to perform part of the contract on their behalf.",
+      "type": "object",
+      "properties": {
+        "id": {
+          "title": "Identifier",
+          "description": "The locally unique identifier for the subcontract.",
+          "type": [
+            "string"
+          ],
+          "minLength": 1
+        },
+        "subcontractor": {
+          "title": "Subcontractor",
+          "description": "The organization that will perform part of the contract on behalf of the tenderers.",
+          "$ref": "#/definitions/OrganizationReference"
+        },
+        "tenderers": {
+          "title": "Tenderers",
+          "description": "The tenderers to which the subcontractor will be subcontracted.",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/OrganizationReference"
+          },
+          "uniqueItems": true,
+          "minItems": 1
+        }
+      },
+      "required": [
+        "id"
+      ],
       "minProperties": 1
     }
   }

--- a/release-schema.json
+++ b/release-schema.json
@@ -39,7 +39,7 @@
       "properties": {
         "hasSubcontracting": {
           "title": "Subcontracting involved",
-          "description": "Whether a part of the contract will be subcontracted.",
+          "description": "Whether a part of the contract will be subcontracted to third parties.",
           "type": [
             "boolean",
             "null"
@@ -68,7 +68,7 @@
         },
         "competitiveMaximumPercentage": {
           "title": "Maximum percentage of contract value for competitive subcontracting",
-          "description": "The maximum percentage of the contract value that the procuring entity requires the supplier to subcontract to third parties through a competitive procedure.",
+          "description": "The maximum percentage of the contract value that the buyer or procuring entity allows the supplier to subcontract to third parties through a competitive procedure.",
           "type": [
             "number",
             "null"
@@ -79,7 +79,7 @@
         },
         "competitiveMinimumPercentage": {
           "title": "Minimum percentage of contract value for competitive subcontracting",
-          "description": "The minimum percentage of the contract value that the procuring entity requires the supplier to subcontract to third parties through a competitive procedure.",
+          "description": "The minimum percentage of the contract value that the buyer or procuring entity requires the supplier to subcontract to third parties through a competitive procedure.",
           "type": [
             "number",
             "null"
@@ -174,7 +174,7 @@
     },
     "Subcontract": {
       "title": "Subcontract",
-      "description": "A relationship that the tenderers will establish with a third party to perform part of the contract on their behalf.",
+      "description": "A relationship that suppliers establish with a third party to perform part of the contract on their behalf.",
       "type": "object",
       "properties": {
         "id": {
@@ -187,7 +187,7 @@
         },
         "subcontractor": {
           "title": "Subcontractor",
-          "description": "The organization that will perform part of the contract on behalf of the tenderers.",
+          "description": "The organization that performs part of the contract on behalf of the suppliers.",
           "$ref": "#/definitions/OrganizationReference"
         },
         "tenderers": {


### PR DESCRIPTION
Based on the discussion in https://github.com/open-contracting/european-union-support/issues/75, I've documented two examples in the readme file: one for tenders and awards (the TED model) and one for lots and bids (the eForms model).